### PR TITLE
Add a Quick Start guide and make options more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 
 ## Introduction
 
-A modern [`setuptools`](https://setuptools.pypa.io/) plugin to generate Python files from proto files using [`betterproto`](https://github.com/danielgtaylor/python-betterproto).
+A modern [`setuptools`](https://setuptools.pypa.io/) plugin to generate Python
+files from proto files using [betterproto].
 
-This plugin is based on [`repo-config`](https://frequenz-floss.github.io/frequenz-repo-config-python/)'s [`grpc_tools` plugin](https://frequenz-floss.github.io/frequenz-repo-config-python/v0.9/reference/frequenz/repo/config/setuptools/grpc_tools/).
+This plugin is based on
+[`repo-config`](https://frequenz-floss.github.io/frequenz-repo-config-python/)'s
+[`grpc_tools`
+plugin](https://frequenz-floss.github.io/frequenz-repo-config-python/v0.9/reference/frequenz/repo/config/setuptools/grpc_tools/).
 
 ## Supported Platforms
 
@@ -18,6 +22,73 @@ The following platforms are officially supported (tested):
 - **Operating System:** Ubuntu Linux 20.04
 - **Architectures:** amd64, arm64
 
+## Quick Start
+
+To add automatic [betterproto] code generation to your project, you need to add
+this package to your build-dependencies in the `pyproject.toml` file, for
+example:
+
+```toml
+[build-system]
+requires = [
+  "setuptools == 68.1.0",
+  "setuptools-betterproto == 0.1.0",
+]
+build-backend = "setuptools.build_meta"
+```
+
+This uses a default configuration as follows:
+
+* `proto_path`: This is the root directory where the proto files are located.
+  By default, it is set to `.`.
+* `proto_glob`: This is the glob pattern to match the proto files. The search
+  is done recursively. By default, it is set to `*.proto`.
+* `include_paths`: This is a list of paths to be added to the protobuf
+  compiler's include path. By default, it is set to `[]`, but the `proto_path`
+  directory is always automatically added.
+* `out_path`: This is the directory where the generated Python files will be
+  placed. By default, it is set to `.`.
+
+These defaults can be changed via the `pypackage.toml` file too. For example:
+
+```toml
+[tool.setuptools_betterproto]
+proto_path = "proto"
+include_paths = ["api-common-protos"]
+out_dir = "src"
+```
+
+You should add [betterproto] as a dependency too, for example:
+
+```toml
+dependencies = ["betterproto == 2.0.0b6"]
+```
+
+You probably also need to add the protobuf files to the `MANIFEST.in` file, so
+they are included in the source distribution. For example (following our
+customized example):
+
+```plaintext
+recursive-include proto *.proto
+```
+
+Once this is done, the conversion of the proto files to Python files should be
+automatic. Just try building the package with:
+
+```sh
+python -m pip install build
+python -m build
+```
+
+A new command to generate the files will be also added to `setuptools`, you can
+run it manually with:
+```sh
+python -c 'import setuptools; setuptools.setup()' build_betterproto
+```
+
+You can also pass the configuration options via command line for quick testing,
+try passing `--help` at the end of the command to see the available options.
+
 ## Contributing
 
 If you want to know how to build this project and contribute to it, please
@@ -26,3 +97,5 @@ check out the [Contributing Guide](CONTRIBUTING.md).
 ## Similar projects
 
 * [`setuptools-proto`](https://github.com/jameslan/setuptools-proto/): We didn't use this project because it seems a bit inactive and not widely used. It also seems to need some configuration as code, which we wanted to avoid.
+
+[betterproto]: https://github.com/danielgtaylor/python-betterproto

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -33,7 +33,7 @@ class CompileProto(setuptools.Command):
     include_paths: str
     """Comma-separated list of paths to include when compiling the protobuf files."""
 
-    out_dir: str
+    out_path: str
     """The path of the root directory where the Python files will be generated."""
 
     description: str = "compile protobuf files using betterproto"
@@ -66,7 +66,7 @@ class CompileProto(setuptools.Command):
         self.proto_path = config.proto_path
         self.proto_glob = config.proto_glob
         self.include_paths = ",".join(config.include_paths)
-        self.out_dir = config.out_dir
+        self.out_path = config.out_path
 
     def finalize_options(self) -> None:
         """Finalize options."""
@@ -95,7 +95,7 @@ class CompileProto(setuptools.Command):
             "-m",
             "grpc_tools.protoc",
             *(f"-I{p}" for p in [self.proto_path, *include_paths]),
-            f"--python_betterproto_out={self.out_dir}",
+            f"--python_betterproto_out={self.out_path}",
             *map(str, proto_files),
         ]
 

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -103,7 +103,7 @@ class CompileProto(setuptools.Command):
         subprocess.run(protoc_cmd, check=True)
 
 
-# This adds the compile_proto command to the build sub-command.
+# This adds the build_betterproto command to the build sub-command.
 # The name of the command is mapped to the class name in the pyproject.toml file,
 # in the [project.entry-points.distutils.commands] section.
 # The None value is an optional function that can be used to determine if the

--- a/src/setuptools_betterproto/_config.py
+++ b/src/setuptools_betterproto/_config.py
@@ -29,7 +29,7 @@ class ProtobufConfig:
     include_paths: Sequence[str] = ()
     """The paths to add to the include path when compiling the protobuf files."""
 
-    out_dir: str = "."
+    out_path: str = "."
     """The path of the root directory where the Python files will be generated."""
 
     @classmethod

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -14,7 +14,7 @@ CONFIG = ProtobufConfig(
     proto_path="test_path",
     proto_glob="*.test",
     include_paths=["test_include1", "test_include2"],
-    out_dir="test_out",
+    out_path="test_out",
 )
 
 
@@ -38,7 +38,7 @@ def test_initialize_options() -> None:
     assert command.proto_path == CONFIG.proto_path
     assert command.proto_glob == CONFIG.proto_glob
     assert command.include_paths == ",".join(CONFIG.include_paths)
-    assert command.out_dir == CONFIG.out_dir
+    assert command.out_path == CONFIG.out_path
 
 
 def test_run() -> None:
@@ -48,7 +48,7 @@ def test_run() -> None:
     command.proto_path = CONFIG.proto_path
     command.proto_glob = CONFIG.proto_glob
     command.include_paths = ",".join(CONFIG.include_paths)
-    command.out_dir = CONFIG.out_dir
+    command.out_path = CONFIG.out_path
 
     with (
         mock.patch(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,7 +38,7 @@ class DefaultsTestCase:
                 "proto_path": "test_path",
                 "proto_glob": "",
                 "include_paths": ("proto",),
-                "out_dir": "generated",
+                "out_path": "generated",
             },
         ),
     ],
@@ -62,13 +62,13 @@ proto_path = "test_path"
 proto_path = "test_path"
 proto_glob = "test_glob"
 include_paths = ["test_include"]
-out_dir = "test_out"
+out_path = "test_out"
 """,
             {
                 "proto_path": "test_path",
                 "proto_glob": "test_glob",
                 "include_paths": ["test_include"],
-                "out_dir": "test_out",
+                "out_path": "test_out",
             },
         ),
     ],
@@ -105,7 +105,7 @@ def test_from_proto(
                 "proto_path": "test_path",
                 "proto_glob": "",
                 "include_paths": ("proto",),
-                "out_dir": "generated",
+                "out_path": "generated",
             },
         ),
     ],


### PR DESCRIPTION
- **Rename `out_dir` to out_path`**
- **Fix reference to the added command**
- **Add a Quick Start section to the README**
