### PR TITLE
Properly include generated Python files in the wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,6 @@ You should add [betterproto] as a dependency too, for example:
 dependencies = ["betterproto == 2.0.0b6"]
 ```
 
-You probably also need to add the protobuf files to the `MANIFEST.in` file, so
-they are included in the source distribution. For example (following our
-customized example):
-
-```plaintext
-recursive-include proto *.proto
-```
-
 Once this is done, the conversion of the proto files to Python files should be
 automatic. Just try building the package with:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ python -m build
 A new command to generate the files will be also added to `setuptools`, you can
 run it manually with:
 ```sh
-python -c 'import setuptools; setuptools.setup()' build_betterproto
+python -c 'import setuptools; setuptools.setup()' compile_betterproto
 ```
 
 You can also pass the configuration options via command line for quick testing,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Betterproto Setuptools plugin Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix a bug where the generated files were not included in the wheel distribution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dynamic = ["version"]
 name = "Frequenz Energy-as-a-Service GmbH"
 email = "floss@frequenz.com"
 
+[project.entry-points."setuptools.finalize_distribution_options"]
+finalize_distribution_options_betterproto = "setuptools_betterproto:finalize_distribution_options"
+
 [project.entry-points."distutils.commands"]
 compile_betterproto = "setuptools_betterproto:CompileBetterproto"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ name = "Frequenz Energy-as-a-Service GmbH"
 email = "floss@frequenz.com"
 
 [project.entry-points."distutils.commands"]
-build_betterproto = "setuptools_betterproto:CompileProto"
+compile_betterproto = "setuptools_betterproto:CompileBetterproto"
 
 [project.optional-dependencies]
 dev-flake8 = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ finalize_distribution_options_betterproto = "setuptools_betterproto:finalize_dis
 
 [project.entry-points."distutils.commands"]
 compile_betterproto = "setuptools_betterproto:CompileBetterproto"
+add_proto_files = "setuptools_betterproto:AddProtoFiles"
 
 [project.optional-dependencies]
 dev-flake8 = [

--- a/src/setuptools_betterproto/__init__.py
+++ b/src/setuptools_betterproto/__init__.py
@@ -3,10 +3,10 @@
 
 """A modern setuptools plugin to generate Python files from proto files using betterproto."""
 
-from ._command import CompileProto
+from ._command import CompileBetterproto
 from ._config import ProtobufConfig
 
 __all__ = [
-    "CompileProto",
+    "CompileBetterproto",
     "ProtobufConfig",
 ]

--- a/src/setuptools_betterproto/__init__.py
+++ b/src/setuptools_betterproto/__init__.py
@@ -3,10 +3,13 @@
 
 """A modern setuptools plugin to generate Python files from proto files using betterproto."""
 
-from ._command import CompileBetterproto
+from ._command import AddProtoFiles, CompileBetterproto
 from ._config import ProtobufConfig
+from ._install import finalize_distribution_options
 
 __all__ = [
+    "AddProtoFiles",
     "CompileBetterproto",
     "ProtobufConfig",
+    "finalize_distribution_options",
 ]

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -19,8 +19,9 @@ import setuptools.command.build as _build_command
 from . import _config
 
 
-class CompileBetterproto(setuptools.Command):
-    """Build the Python protobuf files."""
+
+class BaseProtoCommand(setuptools.Command):
+    """A base class for commands that deal with protobuf files."""
 
     proto_path: str
     """The path of the root directory containing the protobuf files."""
@@ -77,6 +78,10 @@ class CompileBetterproto(setuptools.Command):
             include_paths=self.include_paths,
             out_path=self.out_path,
         )
+
+
+class CompileBetterproto(BaseProtoCommand):
+    """A command to compile the protobuf files."""
 
     def run(self) -> None:
         """Compile the Python protobuf files."""

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -113,11 +113,3 @@ class CompileBetterproto(BaseProtoCommand):
 
         _logger.info("compiling proto files via: %s", " ".join(protoc_cmd))
         subprocess.run(protoc_cmd, check=True)
-
-
-# This adds the build_betterproto command to the build sub-command.
-# The name of the command is mapped to the class name in the pyproject.toml file,
-# in the [project.entry-points.distutils.commands] section.
-# The None value is an optional function that can be used to determine if the
-# sub-command should be executed or not.
-_build_command.build.sub_commands.insert(0, ("compile_betterproto", None))

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -10,6 +10,7 @@ It also runs the command as the first sub-command for the build command, so
 protocol buffer files are compiled automatically before the project is built.
 """
 
+import logging
 import subprocess
 import sys
 
@@ -19,6 +20,7 @@ from typing_extensions import override
 
 from . import _config
 
+_logger = logging.getLogger(__name__)
 
 
 class BaseProtoCommand(setuptools.Command):
@@ -92,9 +94,11 @@ class CompileBetterproto(BaseProtoCommand):
         proto_files = self.config.expanded_proto_files
 
         if not proto_files:
-            print(
-                f"No proto files found in {self.config.proto_path} with glob "
-                f"{self.config.proto_glob}, skipping compilation of proto files."
+            _logger.warning(
+                "No proto files found in %s with glob "
+                "%s, skipping compilation of proto files.",
+                self.config.proto_path,
+                self.config.proto_glob,
             )
             return
 
@@ -107,7 +111,7 @@ class CompileBetterproto(BaseProtoCommand):
             *proto_files,
         ]
 
-        print(f"Compiling proto files via: {' '.join(protoc_cmd)}")
+        _logger.info("compiling proto files via: %s", " ".join(protoc_cmd))
         subprocess.run(protoc_cmd, check=True)
 
 

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -19,7 +19,7 @@ import setuptools.command.build as _build_command
 from . import _config
 
 
-class CompileProto(setuptools.Command):
+class CompileBetterproto(setuptools.Command):
     """Build the Python protobuf files."""
 
     proto_path: str
@@ -107,4 +107,4 @@ class CompileProto(setuptools.Command):
 # in the [project.entry-points.distutils.commands] section.
 # The None value is an optional function that can be used to determine if the
 # sub-command should be executed or not.
-_build_command.build.sub_commands.insert(0, ("build_betterproto", None))
+_build_command.build.sub_commands.insert(0, ("compile_betterproto", None))

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -15,6 +15,7 @@ import sys
 
 import setuptools
 import setuptools.command.build as _build_command
+from typing_extensions import override
 
 from . import _config
 
@@ -61,6 +62,7 @@ class BaseProtoCommand(setuptools.Command):
     ]
     """Options of the command."""
 
+    @override
     def initialize_options(self) -> None:
         """Initialize options."""
         self.config = _config.ProtobufConfig.from_pyproject_toml()
@@ -70,6 +72,7 @@ class BaseProtoCommand(setuptools.Command):
         self.include_paths = ",".join(self.config.include_paths)
         self.out_path = self.config.out_path
 
+    @override
     def finalize_options(self) -> None:
         """Finalize options."""
         self.config = _config.ProtobufConfig.from_strings(
@@ -83,6 +86,7 @@ class BaseProtoCommand(setuptools.Command):
 class CompileBetterproto(BaseProtoCommand):
     """A command to compile the protobuf files."""
 
+    @override
     def run(self) -> None:
         """Compile the Python protobuf files."""
         proto_files = self.config.expanded_proto_files

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -98,8 +98,9 @@ class CompileBetterproto(BaseProtoCommand):
 
         if not proto_files:
             _logger.warning(
-                "No proto files found in %s with glob "
-                "%s, skipping compilation of proto files.",
+                "No proto files were found in the `proto_path` (%s) using `proto_glob` "
+                "(%s). You probably want to check if you `proto_path` and `proto_glob` "
+                "are configured correctly. We are not compiling any proto files!",
                 self.config.proto_path,
                 self.config.proto_glob,
             )

--- a/src/setuptools_betterproto/_command.py
+++ b/src/setuptools_betterproto/_command.py
@@ -79,13 +79,18 @@ class CompileProto(setuptools.Command):
 
     def run(self) -> None:
         """Compile the Python protobuf files."""
-        include_paths = list(map(pathlib.Path, self.include_paths.split(",")))
-        proto_path = pathlib.Path(self.proto_path)
-        proto_files = list(self._expand_paths(proto_path, self.proto_glob))
+        config = _config.ProtobufConfig.from_strings(
+            proto_path=self.proto_path,
+            proto_glob=self.proto_glob,
+            include_paths=self.include_paths,
+            out_path=self.out_path,
+        )
+        proto_path = pathlib.Path(config.proto_path)
+        proto_files = list(self._expand_paths(proto_path, config.proto_glob))
 
         if not proto_files:
             print(
-                f"No proto files found in {self.proto_path}/**/{self.proto_glob}/, "
+                f"No proto files found in {config.proto_path}/**/{config.proto_glob}/, "
                 "skipping compilation of proto files."
             )
             return
@@ -94,8 +99,8 @@ class CompileProto(setuptools.Command):
             sys.executable,
             "-m",
             "grpc_tools.protoc",
-            *(f"-I{p}" for p in [self.proto_path, *include_paths]),
-            f"--python_betterproto_out={self.out_path}",
+            *(f"-I{p}" for p in [config.proto_path, *config.include_paths]),
+            f"--python_betterproto_out={config.out_path}",
             *map(str, proto_files),
         ]
 

--- a/src/setuptools_betterproto/_config.py
+++ b/src/setuptools_betterproto/_config.py
@@ -75,3 +75,27 @@ class ProtobufConfig:
 
         attrs = dict(defaults, **{k: config[k] for k in (known_keys & config_keys)})
         return dataclasses.replace(default, **attrs)
+
+    @classmethod
+    def from_strings(
+        cls, *, proto_path: str, proto_glob: str, include_paths: str, out_path: str
+    ) -> Self:
+        """Create a new configuration from plain strings.
+
+        Args:
+            proto_path: The path of the root directory containing the protobuf files.
+            proto_glob: The glob pattern to use to find the protobuf files.
+            include_paths: The paths to add to the include path when compiling the
+                protobuf files.
+            out_path: The path of the root directory where the Python files will be
+                generated.
+
+        Returns:
+            The configuration.
+        """
+        return cls(
+            proto_path=proto_path,
+            proto_glob=proto_glob,
+            include_paths=[p.strip() for p in include_paths.split(",")],
+            out_path=out_path,
+        )

--- a/src/setuptools_betterproto/_config.py
+++ b/src/setuptools_betterproto/_config.py
@@ -106,3 +106,12 @@ class ProtobufConfig:
         """The files in the `proto_path` expanded according to the configured glob."""
         proto_path = pathlib.Path(self.proto_path)
         return [str(proto_file) for proto_file in proto_path.rglob(self.proto_glob)]
+
+    @property
+    def expanded_include_files(self) -> list[str]:
+        """The files in the `include_paths` expanded according to the configured glob."""
+        return [
+            str(proto_file)
+            for include_path in map(pathlib.Path, self.include_paths)
+            for proto_file in include_path.rglob(self.proto_glob)
+        ]

--- a/src/setuptools_betterproto/_config.py
+++ b/src/setuptools_betterproto/_config.py
@@ -5,6 +5,7 @@
 
 import dataclasses
 import logging
+import pathlib
 import tomllib
 from collections.abc import Sequence
 from typing import Any, Self
@@ -99,3 +100,9 @@ class ProtobufConfig:
             include_paths=[p.strip() for p in include_paths.split(",")],
             out_path=out_path,
         )
+
+    @property
+    def expanded_proto_files(self) -> list[str]:
+        """The files in the `proto_path` expanded according to the configured glob."""
+        proto_path = pathlib.Path(self.proto_path)
+        return [str(proto_file) for proto_file in proto_path.rglob(self.proto_glob)]

--- a/src/setuptools_betterproto/_install.py
+++ b/src/setuptools_betterproto/_install.py
@@ -1,0 +1,31 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Setuptools hook entry-point to finalize the distribution options.
+
+The `finalize_distribution_options` function is called by setuptools to finalize the
+distribution options. It adds the `compile_betterproto` command to the build
+sub-commands.
+"""
+
+import setuptools.command.build as _build_command
+from setuptools.dist import Distribution
+
+
+def finalize_distribution_options(dist: Distribution) -> None:
+    """Make some final adjustments to the distribution options.
+
+    We need to do some stuff early when setuptools runs to make sure all files are
+    compiled and distributed appropriately.
+
+    Args:
+        dist: The distribution object.
+    """
+    add_build_subcommand_compile_betterproto(dist)
+
+
+def add_build_subcommand_compile_betterproto(dist: Distribution) -> None:
+    """Add the compile_betterproto command to the build sub-commands."""
+    sdist_cmd = dist.get_command_obj("build")
+    assert isinstance(sdist_cmd, _build_command.build)
+    sdist_cmd.sub_commands.append(("compile_betterproto", None))

--- a/src/setuptools_betterproto/_install.py
+++ b/src/setuptools_betterproto/_install.py
@@ -6,6 +6,13 @@
 The `finalize_distribution_options` function is called by setuptools to finalize the
 distribution options. It adds the `compile_betterproto` command to the build sub-commands
 and replaces the `sdist` command with a custom one that includes the proto files.
+
+It will also build the proto files early if the distribution is a binary distribution.
+This is necessary to include the generated Python files in the binary distribution,
+otherwise the file discovery runs before we manage to compile the proto files.
+
+We still need to hook the sub-command into the build command to make sure editable
+installs work correctly.
 """
 
 import logging
@@ -27,6 +34,7 @@ def finalize_distribution_options(dist: Distribution) -> None:
 
     1. Replace the sdist command with a custom one that includes the proto files.
     2. Add the `compile_betterproto` command to the build sub-commands.
+    3. If the distribution is a binary distribution, build the proto files early.
 
     Args:
         dist: The distribution object.
@@ -34,6 +42,20 @@ def finalize_distribution_options(dist: Distribution) -> None:
     config = _config.ProtobufConfig.from_pyproject_toml()
     replace_sdist_command(dist)
     add_build_subcommand_compile_betterproto(dist)
+
+    if not building_bdist(dist):
+        return
+
+    if not config.expanded_proto_files:
+        _logger.warning(
+            "No proto files found in %s with glob %s, skipping early automatic "
+            "compilation of proto files.",
+            config.proto_path,
+            config.proto_glob,
+        )
+        return
+
+    build_proto(dist)
 
 
 def add_build_subcommand_compile_betterproto(dist: Distribution) -> None:
@@ -46,3 +68,24 @@ def add_build_subcommand_compile_betterproto(dist: Distribution) -> None:
 def replace_sdist_command(dist: Distribution) -> None:
     """Replace the sdist command with a custom one that includes the proto files."""
     dist.cmdclass.update(sdist=_command.SdistWithProtoFiles)
+
+
+def building_bdist(dist: Distribution) -> bool:
+    """Check if the distribution is a binary distribution."""
+    if not isinstance(dist.script_args, Container):
+        return False
+    for arg in dist.script_args:
+        if arg.startswith("bdist"):
+            return True
+    return False
+
+
+def build_proto(dist: Distribution) -> None:
+    """Build the Python protobuf files."""
+    _logger.info(
+        "Compiling protobuf files early so they are included in the binary distribution."
+    )
+    compile_cmg = _command.CompileBetterproto(dist)
+    compile_cmg.initialize_options()
+    compile_cmg.finalize_options()
+    compile_cmg.run()

--- a/src/setuptools_betterproto/_install.py
+++ b/src/setuptools_betterproto/_install.py
@@ -4,12 +4,19 @@
 """Setuptools hook entry-point to finalize the distribution options.
 
 The `finalize_distribution_options` function is called by setuptools to finalize the
-distribution options. It adds the `compile_betterproto` command to the build
-sub-commands.
+distribution options. It adds the `compile_betterproto` command to the build sub-commands
+and replaces the `sdist` command with a custom one that includes the proto files.
 """
+
+import logging
+from collections.abc import Container
 
 import setuptools.command.build as _build_command
 from setuptools.dist import Distribution
+
+from . import _command, _config
+
+_logger = logging.getLogger(__name__)
 
 
 def finalize_distribution_options(dist: Distribution) -> None:
@@ -18,9 +25,14 @@ def finalize_distribution_options(dist: Distribution) -> None:
     We need to do some stuff early when setuptools runs to make sure all files are
     compiled and distributed appropriately.
 
+    1. Replace the sdist command with a custom one that includes the proto files.
+    2. Add the `compile_betterproto` command to the build sub-commands.
+
     Args:
         dist: The distribution object.
     """
+    config = _config.ProtobufConfig.from_pyproject_toml()
+    replace_sdist_command(dist)
     add_build_subcommand_compile_betterproto(dist)
 
 
@@ -29,3 +41,8 @@ def add_build_subcommand_compile_betterproto(dist: Distribution) -> None:
     sdist_cmd = dist.get_command_obj("build")
     assert isinstance(sdist_cmd, _build_command.build)
     sdist_cmd.sub_commands.append(("compile_betterproto", None))
+
+
+def replace_sdist_command(dist: Distribution) -> None:
+    """Replace the sdist command with a custom one that includes the proto files."""
+    dist.cmdclass.update(sdist=_command.SdistWithProtoFiles)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -9,7 +9,7 @@ from unittest import mock
 from setuptools import Distribution
 from typing_extensions import override
 
-from setuptools_betterproto import CompileProto, ProtobufConfig
+from setuptools_betterproto import CompileBetterproto, ProtobufConfig
 
 CONFIG = ProtobufConfig(
     proto_path="test_path",
@@ -19,11 +19,11 @@ CONFIG = ProtobufConfig(
 )
 
 
-def create_command() -> CompileProto:
+def create_command() -> CompileBetterproto:
     """Create a new instance of the command with a mocked distribution."""
     dist = mock.MagicMock(spec=Distribution)
     dist.verbose = True
-    return CompileProto(dist)
+    return CompileBetterproto(dist)
 
 
 def test_initialize_options() -> None:


### PR DESCRIPTION
When building the wheel, the setuptools file discovery feature runs before the `compile_betterproto` sub-command is run, so the files are not included in the resulting wheel.

To overcome this issue we use a hack, by running the compile command early when the distribution options are being finalized, we make sure the files are present by the time the file discovery runs.

This is very hacky though, and even when it seems to work well in all tested cases (calling setuptools` `setup()` directly, `build`, `pip install`, `pip install -e`), I wouldn't be very surprised if it breaks in the future, so we probably will have to have an eye on it.

Unfortunately it seems there is no easy way to do this with setuptools:

* https://github.com/pypa/setuptools/discussions/3180#discussioncomment-2422328
* https://github.com/pypa/setuptools/issues/2591

This PR also includes some other improvements, including:

* Better abstraction of the configuration object
* Better hooking into setuptools
* Use of logging instead of print
* Better name for the command to compile the proto files
