### PR TITLE
Add Python 3.10 support (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These defaults can be changed via the `pypackage.toml` file too. For example:
 [tool.setuptools_betterproto]
 proto_path = "proto"
 include_paths = ["api-common-protos"]
-out_dir = "src"
+out_path = "src"
 ```
 
 You should add [betterproto] as a dependency too, for example:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+ - Fix an issue when `include_paths` is not specified in the `pyproject.toml`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,14 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+ - *Partial support* of Python 3.10:
+
+   The python package can be used as is. But for testing purposes,
+   dependencies must be installed using `--ignore-requires-python`.
+
+   ```bash
+   python -m pip install --ignore-requires-python -e .[dev]
+   ```
 
 ## Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,13 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "Typing :: Typed",
 ]
-requires-python = ">= 3.11, < 4"
+requires-python = ">= 3.10, < 4"
 dependencies = [
   "betterproto[compiler] == 2.0.0b6",
   "grpcio-tools >= 1.59.0, < 2",
   "setuptools >= 67.6.0",
   "typing-extensions >= 4.5.0, < 5",
+  "tomli >= 2.0.1, < 3; python_version < '3.11'",
 ]
 dynamic = ["version"]
 

--- a/src/setuptools_betterproto/_config.py
+++ b/src/setuptools_betterproto/_config.py
@@ -6,9 +6,16 @@
 import dataclasses
 import logging
 import pathlib
-import tomllib
+import sys
 from collections.abc import Sequence
-from typing import Any, Self
+from typing import Any
+
+from typing_extensions import Self
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 _logger = logging.getLogger(__name__)
 

--- a/src/setuptools_betterproto/_config.py
+++ b/src/setuptools_betterproto/_config.py
@@ -97,7 +97,7 @@ class ProtobufConfig:
         return cls(
             proto_path=proto_path,
             proto_glob=proto_glob,
-            include_paths=[p.strip() for p in include_paths.split(",")],
+            include_paths=[p.strip() for p in filter(None, include_paths.split(","))],
             out_path=out_path,
         )
 


### PR DESCRIPTION
All tests are passing but I have to workaround the installation of the `repo-config` package like this:

```
python -m pip install --ignore-requires-python "frequenz-repo-config[extra-lint-examples] == 0.9.2"

python -m pip install -e .[dev]

pytest
```